### PR TITLE
Issue using label-field

### DIFF
--- a/paper-select.html
+++ b/paper-select.html
@@ -89,7 +89,7 @@ Example:
       <paper-menu id="optionsMenu" hidden$="{{!_showOptions}}" i-tabindex="0">
         <template id="optionsRepeat" is="dom-repeat" items="{{options}}">
           <paper-item on-tap="_optionItemTapped" on-keydown="_optionItemKeyUp" tabindex="0">
-            <span>[[{_labelOf(item)]]</span>
+            <span>[[_labelOf(item)]]</span>
             <paper-ripple></paper-ripple>
           </paper-item>
         </template>


### PR DESCRIPTION
Getting the following warning when attempting to use label-field: `[paper-select::_annotatedComputationEffect]: compute method '{_labelOf' not defined`

This is because of an extra caret added to the menu's compute function binding.
